### PR TITLE
Add scatter_columns() to libspn

### DIFF
--- a/libspn/graph/node.py
+++ b/libspn/graph/node.py
@@ -695,12 +695,19 @@ class OpNode(Node):
             list of Tensor: A list of tensors containing scattered values.
         """
         with tf.op_scope([t[0] for t in tuples], "scatter_to_input_tensors"):
+            # return tuple(None if not i or t is None
+            #              else t[0] if i.indices is None
+            #              else utils.scatter_cols(
+            #                  t[0], i.indices,
+            #                  int(t[1].get_shape()
+            #                      [0 if t[1].get_shape().ndims == 1 else 1]))
+            #              for i, t in zip(self.inputs, tuples))
             return tuple(None if not i or t is None
                          else t[0] if i.indices is None
-                         else utils.scatter_cols(
+                         else utils.scatter_columns_module.scatter_columns(
                              t[0], i.indices,
                              int(t[1].get_shape()
-                                 [0 if t[1].get_shape().ndims == 1 else 1]))
+                                 [0 if t[1].get_shape().ndims == 1 else 1]), 0)
                          for i, t in zip(self.inputs, tuples))
 
     @abstractmethod

--- a/libspn/tests/test_math.py
+++ b/libspn/tests/test_math.py
@@ -211,6 +211,69 @@ class TestMath(unittest.TestCase):
              tf.float64,
              [30.0, 10.0, 0.0, 20.0])
 
+    def test_scatter_columns(self):
+        def test(params, indices, num_cols, dtype, true_output):
+            with self.subTest(params=params, indices=indices,
+                              num_cols=num_cols, dtype=dtype):
+                p1d = tf.constant(params, dtype=dtype)
+                p2d1 = tf.constant(np.array([np.array(params)]), dtype=dtype)
+                p2d2 = tf.constant(np.array([np.array(params),
+                                             np.array(params) * 2,
+                                             np.array(params) * 3]), dtype=dtype)
+                op1d = spn.utils.scatter_columns_module.scatter_columns(p1d, indices, num_cols, 0)
+                op2d1 = spn.utils.scatter_columns_module.scatter_columns(p2d1, indices, num_cols, 0)
+                op2d2 = spn.utils.scatter_columns_module.scatter_columns(p2d2, indices, num_cols, 0)
+                with tf.Session() as sess:
+                    out1d = sess.run(op1d)
+                    out2d1 = sess.run(op2d1)
+                    out2d2 = sess.run(op2d2)
+                np.testing.assert_array_almost_equal(out1d, true_output)
+                self.assertEqual(dtype.as_numpy_dtype, out1d.dtype)
+                true_output_2d1 = [np.array(true_output)]
+                true_output_2d2 = [np.array(true_output),
+                                   np.array(true_output) * 2,
+                                   np.array(true_output) * 3]
+                np.testing.assert_array_almost_equal(out2d1, true_output_2d1)
+                np.testing.assert_array_almost_equal(out2d2, true_output_2d2)
+                self.assertEqual(dtype.as_numpy_dtype, out2d1.dtype)
+                self.assertEqual(dtype.as_numpy_dtype, out2d2.dtype)
+
+        # Single column output
+        test([10],
+             [0],
+             1,
+             tf.float32,
+             [10.0])
+        test([10],
+             [0],
+             1,
+             tf.float64,
+             [10.0])
+
+        # Multi-column output, single-column input
+        test([10],
+             [1],
+             4,
+             tf.float32,
+             [0.0, 10.0, 0.0, 0.0])
+        test([10],
+             [0],
+             4,
+             tf.float64,
+             [10.0, 0.0, 0.0, 0.0])
+
+        # Multi-column output, multi-column input
+        test([10, 20, 30],
+             [1, 3, 0],
+             4,
+             tf.float32,
+             [30.0, 10.0, 0.0, 20.0])
+        test([10, 20, 30],
+             [1, 3, 0],
+             4,
+             tf.float64,
+             [30.0, 10.0, 0.0, 20.0])
+
     def test_broadcast_value(self):
         """broadcast_value for various value types"""
 

--- a/libspn/utils/__init__.py
+++ b/libspn/utils/__init__.py
@@ -9,6 +9,7 @@
 
 from .math import gather_cols
 from .math import scatter_cols
+from .math import scatter_columns_module
 from .math import ValueType
 from .math import broadcast_value
 from .math import normalize_tensor
@@ -30,7 +31,7 @@ from .serialization import str2type, type2str
 
 
 # All
-__all__ = ['scatter_cols', 'gather_cols', 'ValueType',
+__all__ = ['scatter_cols', 'scatter_columns_module', 'gather_cols', 'ValueType',
            'broadcast_value', 'normalize_tensor',
            'reduce_log_sum', 'concat_maybe', 'split',
            'StirlingNumber', 'StirlingRatio', 'Stirling',

--- a/libspn/utils/math.py
+++ b/libspn/utils/math.py
@@ -12,6 +12,7 @@ import math
 import numpy as np
 from libspn import utils
 
+scatter_columns_module = tf.load_op_library('/home/nash/Dropbox/KTH/Projects/tensorflow/tensorflow/core/user_ops/scatter_columns.so')
 
 class ValueType:
 


### PR DESCRIPTION
Added scatter_columns() in parallel to py implementation scatter_cols() to libspn. Replaced utils.scatter_cols(...) with utils.scatter_columns_module.scatter_columns(...) in node.py.